### PR TITLE
READMEの環境構築手順を修正しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@
 ./docker-compose-local.sh up
 ```
 
-### 5. プロジェクト直下で「./composer.sh install」を実行
+### 5. 「Docker コンテナ」を起動した状態で、マイグレートする
+
+```
+make migrate
+```
 
 # 機能一覧
 


### PR DESCRIPTION
## 変更内容
- READMEの環境構築手順に、「./composer.sh install」を記述していたが、Docker起動時にvendorディレクトリがなければ、composer installを実行するようになっていた為、手順から削除した
- make migrateコマンド実行の手順が漏れていた為、記述した